### PR TITLE
[FLINK-22452][Connectors/Kafka] Support specifying custom transactional.id prefix in FlinkKafkaProducer

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -248,6 +248,9 @@ public class FlinkKafkaProducer<IN>
     /** Flag controlling whether we are writing the Flink record's timestamp into Kafka. */
     protected boolean writeTimestampToKafka = false;
 
+    /** The transactional.id prefix to be used by the producers when communicating with Kafka. */
+    private String transactionalIdPrefix = null;
+
     /** Flag indicating whether to accept failures (and log them), or to fail on failures. */
     private boolean logFailuresOnly;
 
@@ -775,6 +778,22 @@ public class FlinkKafkaProducer<IN>
     }
 
     /**
+     * Specifies the prefix of the transactional.id property to be used by the producers when
+     * communicating with Kafka. If not set, the transaction.id will be prefixed with {@code
+     * taskName + "-" + operatorUid}.
+     *
+     * <p>Note that, if we change the prefix when the Flink application previously failed before
+     * first checkpoint completed or we are starting new batch of {@link FlinkKafkaProducer} from
+     * scratch without clean shutdown of the previous one, since we don't know what was the
+     * previously used transactional.id prefix, there will be some lingering transactions left.
+     *
+     * @param transactionalIdPrefix the transactional.id prefix
+     */
+    public void setTransactionalIdPrefix(String transactionalIdPrefix) {
+        this.transactionalIdPrefix = transactionalIdPrefix;
+    }
+
+    /**
      * Disables the propagation of exceptions thrown when committing presumably timed out Kafka
      * transactions during recovery of the job. If a Kafka transaction is timed out, a commit will
      * never be successful. Hence, use this feature to avoid recovery loops of the Job. Exceptions
@@ -1149,22 +1168,28 @@ public class FlinkKafkaProducer<IN>
             migrateNextTransactionalIdHindState(context);
         }
 
-        String taskName = getRuntimeContext().getTaskName();
-        // Kafka transactional IDs are limited in length to be less than the max value of a short,
-        // so we truncate here if necessary to a more reasonable length string.
-        if (taskName.length() > maxTaskNameSize) {
-            taskName = taskName.substring(0, maxTaskNameSize);
-            LOG.warn(
-                    "Truncated task name for Kafka TransactionalId from {} to {}.",
-                    getRuntimeContext().getTaskName(),
-                    taskName);
+        String transactionalIdPrefix;
+        if (this.transactionalIdPrefix != null) {
+            transactionalIdPrefix = this.transactionalIdPrefix;
+        } else {
+            String taskName = getRuntimeContext().getTaskName();
+            // Kafka transactional IDs are limited in length to be less than the max value of
+            // a short, so we truncate here if necessary to a more reasonable length string.
+            if (taskName.length() > maxTaskNameSize) {
+                taskName = taskName.substring(0, maxTaskNameSize);
+                LOG.warn(
+                        "Truncated task name for Kafka TransactionalId from {} to {}.",
+                        getRuntimeContext().getTaskName(),
+                        taskName);
+            }
+            transactionalIdPrefix =
+                    taskName
+                            + "-"
+                            + ((StreamingRuntimeContext) getRuntimeContext()).getOperatorUniqueID();
         }
         transactionalIdsGenerator =
                 new TransactionalIdsGenerator(
-                        taskName
-                                + "-"
-                                + ((StreamingRuntimeContext) getRuntimeContext())
-                                        .getOperatorUniqueID(),
+                        transactionalIdPrefix,
                         getRuntimeContext().getIndexOfThisSubtask(),
                         getRuntimeContext().getNumberOfParallelSubtasks(),
                         kafkaProducersPoolSize,

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -33,6 +33,7 @@ import kafka.server.KafkaServer;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,8 +49,12 @@ import java.util.stream.IntStream;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /** IT cases for the {@link FlinkKafkaProducer}. */
 public class FlinkKafkaProducerITCase extends KafkaTestBase {
@@ -595,6 +600,93 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
                 FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
         assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47));
         deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testCustomizeTransactionalIdPrefix() throws Exception {
+        String transactionalIdPrefix = "my-prefix";
+
+        Properties properties = createProperties();
+        String topic = "testCustomizeTransactionalIdPrefix";
+        FlinkKafkaProducer<Integer> kafkaProducer =
+                spy(
+                        new FlinkKafkaProducer<>(
+                                topic,
+                                integerKeyedSerializationSchema,
+                                properties,
+                                FlinkKafkaProducer.Semantic.EXACTLY_ONCE));
+        kafkaProducer.setTransactionalIdPrefix(transactionalIdPrefix);
+
+        try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(kafkaProducer), IntSerializer.INSTANCE)) {
+            testHarness.setup();
+            testHarness.open();
+            testHarness.processElement(1, 0);
+            testHarness.snapshot(0, 1);
+        }
+
+        ArgumentCaptor<FlinkKafkaProducer.KafkaTransactionState> stateCaptor =
+                ArgumentCaptor.forClass(FlinkKafkaProducer.KafkaTransactionState.class);
+        verify(kafkaProducer).invoke(stateCaptor.capture(), any(), any());
+
+        deleteTestTopic(topic);
+        checkProducerLeak();
+
+        FlinkKafkaProducer.KafkaTransactionState state = stateCaptor.getValue();
+        assertThat(state.transactionalId, startsWith(transactionalIdPrefix));
+    }
+
+    @Test
+    public void testRestoreUsingDifferentTransactionalIdPrefix() throws Exception {
+        String topic = "testCustomizeTransactionalIdPrefix";
+        Properties properties = createProperties();
+
+        final String transactionalIdPrefix1 = "my-prefix1";
+        FlinkKafkaProducer<Integer> kafkaProducer1 =
+                new FlinkKafkaProducer<>(
+                        topic,
+                        integerKeyedSerializationSchema,
+                        properties,
+                        FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+        kafkaProducer1.setTransactionalIdPrefix(transactionalIdPrefix1);
+        OperatorSubtaskState snapshot;
+        try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness1 =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(kafkaProducer1), IntSerializer.INSTANCE)) {
+            testHarness1.setup();
+            testHarness1.open();
+            testHarness1.processElement(42, 0);
+            snapshot = testHarness1.snapshot(0, 1);
+
+            testHarness1.processElement(43, 2);
+        }
+
+        final String transactionalIdPrefix2 = "my-prefix2";
+        FlinkKafkaProducer<Integer> kafkaProducer2 =
+                new FlinkKafkaProducer<>(
+                        topic,
+                        integerKeyedSerializationSchema,
+                        properties,
+                        FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+        kafkaProducer2.setTransactionalIdPrefix(transactionalIdPrefix2);
+        try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness2 =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(kafkaProducer2), IntSerializer.INSTANCE)) {
+            testHarness2.setup();
+            // restore from the previous snapshot, transactions with records 43 should be aborted
+            testHarness2.initializeState(snapshot);
+            testHarness2.open();
+
+            testHarness2.processElement(44, 3);
+            testHarness2.snapshot(1, 4);
+            testHarness2.processElement(45, 5);
+            testHarness2.notifyOfCompletedCheckpoint(1);
+            testHarness2.processElement(46, 6);
+        }
+
+        assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 44));
+        checkProducerLeak();
     }
 
     private void testRecoverWithChangeSemantics(


### PR DESCRIPTION
This is a draft pr to trigger an azp build.
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
