### PR TITLE
[Flink-25728] Protential memory leeks in StreamMultipleInputProcessor

### DIFF
--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
@@ -51,7 +51,11 @@ import java.util.stream.Collectors;
  */
 public class MultipleInputStreamMemoryIssueTest {
 
-    public static class ListAgg<IN> implements AggregateFunction<IN, List<IN>, List<IN>> {
+    /**
+     * List Aggregation.
+     * @param <IN>
+     */
+    static class ListAgg<IN> implements AggregateFunction<IN, List<IN>, List<IN>> {
 
         @Override
         public List<IN> createAccumulator() {

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
@@ -46,13 +46,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * MultipleInputStreamTask Memory issue test.
- */
+/** MultipleInputStreamTask Memory issue test. */
 public class MultipleInputStreamMemoryIssueTest {
 
     /**
      * List Aggregation.
+     *
      * @param <IN>
      */
     static class ListAgg<IN> implements AggregateFunction<IN, List<IN>, List<IN>> {
@@ -161,9 +160,11 @@ public class MultipleInputStreamMemoryIssueTest {
                                                 acc += 1;
                                             } else if (ct
                                                     > (Duration.ofSeconds(10).toMillis() / 100)) {
-                                                //recover from idle
-//                                                ct = 0;
-//                                                isIdle = false;
+                                                // recover from idle
+                                                //                                                ct
+                                                // = 0;
+                                                //
+                                                // isIdle = false;
                                             } else if (!isIdle) {
                                                 isIdle = true;
                                                 ctx.markAsTemporarilyIdle();

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
@@ -157,8 +157,9 @@ public class MultipleInputStreamMemoryIssueTest {
                                                 acc += 1;
                                             } else if (ct
                                                     > (Duration.ofSeconds(10).toMillis() / 100)) {
-                                                ct = 0;
-                                                isIdle = false;
+                                                //recover from idle
+//                                                ct = 0;
+//                                                isIdle = false;
                                             } else if (!isIdle) {
                                                 isIdle = true;
                                                 ctx.markAsTemporarilyIdle();

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/MultipleInputStreamMemoryIssueTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
+import org.apache.flink.streaming.api.windowing.triggers.CountTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeoutTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.PurgingTrigger;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * MultipleInputStreamTask Memory issue test.
+ */
+public class MultipleInputStreamMemoryIssueTest {
+
+    public static class ListAgg<IN> implements AggregateFunction<IN, List<IN>, List<IN>> {
+
+        @Override
+        public List<IN> createAccumulator() {
+            return Lists.newArrayList();
+        }
+
+        @Override
+        public List<IN> add(IN value, List<IN> accumulator) {
+            accumulator.add(value);
+            return accumulator;
+        }
+
+        @Override
+        public List<IN> getResult(List<IN> accumulator) {
+            return accumulator;
+        }
+
+        @Override
+        public List<IN> merge(List<IN> a, List<IN> b) {
+            List<IN> res = new ArrayList<IN>(a.size() + b.size());
+            res.addAll(a);
+            res.addAll(b);
+            return res;
+        }
+    }
+
+    public static void main(String[] args) {
+        final StreamExecutionEnvironment environment =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        environment.getConfig().setAutoWatermarkInterval(200);
+        environment.getConfig().enableObjectReuse();
+        environment.getConfig().enableClosureCleaner();
+        environment.getConfig().setLatencyTrackingInterval(1000);
+
+        DataStream<Tuple2<Integer, Integer>> source1 =
+                environment.addSource(
+                        new RichSourceFunction<Tuple2<Integer, Integer>>() {
+                            private transient int ct = 0;
+                            private transient boolean isRunning = true;
+
+                            @Override
+                            public void open(Configuration parameters) throws Exception {
+                                super.open(parameters);
+                                ct = 0;
+                                isRunning = true;
+                            }
+
+                            @Override
+                            public void run(SourceContext<Tuple2<Integer, Integer>> ctx)
+                                    throws Exception {
+                                while (isRunning) {
+                                    ct += 1;
+                                    ctx.collectWithTimestamp(
+                                            Tuple2.of(1, ct), System.currentTimeMillis());
+                                    try {
+                                        Thread.sleep(1);
+                                    } catch (InterruptedException e) {
+                                        // ignored
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public void cancel() {
+                                isRunning = false;
+                            }
+                        });
+
+        MapStateDescriptor<String, List<Tuple2<Integer, Integer>>> desc =
+                new MapStateDescriptor<>(
+                        "broadcast-state",
+                        BasicTypeInfo.STRING_TYPE_INFO,
+                        new ListTypeInfo<>(
+                                TypeInformation.of(new TypeHint<Tuple2<Integer, Integer>>() {})));
+
+        BroadcastStream<List<Tuple2<Integer, Integer>>> source2 =
+                environment
+                        .addSource(
+                                new RichSourceFunction<Tuple2<Integer, Integer>>() {
+
+                                    private transient int ct = 0;
+                                    private transient boolean isRunning = true;
+                                    private transient boolean isIdle = false;
+                                    private transient int acc = 0;
+
+                                    @Override
+                                    public void open(Configuration parameters) throws Exception {
+                                        super.open(parameters);
+                                        ct = 0;
+                                        isRunning = true;
+                                        isIdle = false;
+                                        acc = 0;
+                                    }
+
+                                    @Override
+                                    public void run(SourceContext<Tuple2<Integer, Integer>> ctx)
+                                            throws Exception {
+                                        while (isRunning) {
+                                            if (ct < 10) {
+                                                ctx.collectWithTimestamp(
+                                                        Tuple2.of(2, acc),
+                                                        System.currentTimeMillis());
+                                                acc += 1;
+                                            } else if (ct
+                                                    > (Duration.ofSeconds(10).toMillis() / 100)) {
+                                                ct = 0;
+                                                isIdle = false;
+                                            } else if (!isIdle) {
+                                                isIdle = true;
+                                                ctx.markAsTemporarilyIdle();
+                                            }
+                                            ct += 1;
+                                            try {
+                                                Thread.sleep(100);
+                                            } catch (InterruptedException e) {
+                                                // ignored
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void cancel() {
+                                        isRunning = false;
+                                    }
+                                })
+                        .windowAll(GlobalWindows.create())
+                        .trigger(
+                                PurgingTrigger.of(
+                                        ProcessingTimeoutTrigger.of(
+                                                CountTrigger.of(100),
+                                                Duration.ofSeconds(1),
+                                                true,
+                                                true)))
+                        .aggregate(new ListAgg<>())
+                        .name("diagnosis-config-buffering")
+                        .setParallelism(1)
+                        .broadcast(desc);
+
+        DataStream<Tuple2<Integer, Integer>> stream1 =
+                source1.connect(source2)
+                        .process(
+                                new BroadcastProcessFunction<
+                                        Tuple2<Integer, Integer>,
+                                        List<Tuple2<Integer, Integer>>,
+                                        Tuple2<Integer, Integer>>() {
+                                    @Override
+                                    public void processElement(
+                                            Tuple2<Integer, Integer> value,
+                                            ReadOnlyContext ctx,
+                                            Collector<Tuple2<Integer, Integer>> out)
+                                            throws Exception {
+                                        out.collect(value);
+                                    }
+
+                                    @Override
+                                    public void processBroadcastElement(
+                                            List<Tuple2<Integer, Integer>> value,
+                                            Context ctx,
+                                            Collector<Tuple2<Integer, Integer>> out)
+                                            throws Exception {
+                                        System.out.println(
+                                                String.format(
+                                                        "broadcast %d ,[%s]",
+                                                        value.size(),
+                                                        value.stream()
+                                                                .map(String::valueOf)
+                                                                .collect(Collectors.joining(","))));
+                                    }
+                                })
+                        .process(
+                                new ProcessFunction<
+                                        Tuple2<Integer, Integer>, Tuple2<Integer, Integer>>() {
+                                    @Override
+                                    public void processElement(
+                                            Tuple2<Integer, Integer> value,
+                                            ProcessFunction<
+                                                                    Tuple2<Integer, Integer>,
+                                                                    Tuple2<Integer, Integer>>
+                                                            .Context
+                                                    ctx,
+                                            Collector<Tuple2<Integer, Integer>> out)
+                                            throws Exception {
+                                        out.collect(value);
+                                    }
+                                });
+
+        stream1.addSink(new DiscardingSink<>()).setParallelism(10);
+
+        try {
+            environment.execute("dummy_multiple_input_test");
+        } catch (Exception error) {
+            error.printStackTrace();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4-rule-agent</artifactId>
+			<version>${powermock.version}</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito2</artifactId>
 			<version>${powermock.version}</version>
 			<type>jar</type>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
